### PR TITLE
Mandatory pass isHotfixEnabled flag to JiraComponentVersion, set no hotfixVersion if it is not supported. 

### DIFF
--- a/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
+++ b/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
@@ -209,7 +209,7 @@ public class JiraComponentVersionFormatter {
                 StringUtils.isNotBlank(jiraComponent.getComponentInfo().getVersionPrefix());
     }
 
-    public String normalizeVersion(JiraComponent component, String version, VersionNames versionNames, boolean isHotfixEnabled,  boolean strict) {
+    public String normalizeVersion(JiraComponent component, String version, boolean isHotfixEnabled, boolean strict) {
 
         if (component != null ) {
             IVersionInfo numericVersion = numericVersionFactory.create(version);

--- a/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
+++ b/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
@@ -208,11 +208,11 @@ public class JiraComponentVersionFormatter {
                 StringUtils.isNotBlank(jiraComponent.getComponentInfo().getVersionPrefix());
     }
 
-    public String normalizeVersion(JiraComponent component, String version, boolean strict, boolean isHotfixEnabled) {
+    public String normalizeVersion(JiraComponent component, String version, boolean strict, boolean hotfixEnabled) {
 
-        if (component != null ) {
+        if (component != null) {
             IVersionInfo numericVersion = numericVersionFactory.create(version);
-            if (isHotfixEnabled && matchesHotfixVersionFormat(component, version, strict)) {
+            if (hotfixEnabled && matchesHotfixVersionFormat(component, version, strict)) {
                 return numericVersion.formatVersion(component.getComponentVersionFormat().getHotfixVersionFormat());
             }
             if (matchesBuildVersionFormat(component, version, strict)) {
@@ -233,6 +233,5 @@ public class JiraComponentVersionFormatter {
         }
         return null;
     }
-
 
 }

--- a/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
+++ b/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.releng;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.octopusden.octopus.releng.dto.ComponentInfo;
 import org.octopusden.octopus.releng.dto.JiraComponent;
@@ -207,5 +208,33 @@ public class JiraComponentVersionFormatter {
         return jiraComponent.getComponentInfo() != null &&
                 StringUtils.isNotBlank(jiraComponent.getComponentInfo().getVersionPrefix());
     }
+
+    @JsonIgnore
+    public String normalizeVersion(JiraComponent component, String version, VersionNames versionNames, boolean isHotfixEnabled,  boolean strict) {
+
+        if (component != null ) {
+            IVersionInfo numericVersion = new NumericVersionFactory(versionNames).create(version);
+            if (isHotfixEnabled && matchesHotfixVersionFormat(component, version, strict)) {
+                return numericVersion.formatVersion(component.getComponentVersionFormat().getHotfixVersionFormat());
+            }
+            if (matchesBuildVersionFormat(component, version, strict)) {
+                return numericVersion.formatVersion(getBuildVersionFormat(component));
+            }
+            if (matchesRCVersionFormat(component, version, strict)) {
+                return numericVersion.formatVersion(component.getComponentVersionFormat().getReleaseVersionFormat());
+            }
+            if (matchesReleaseVersionFormat(component, version, strict)) {
+                return numericVersion.formatVersion(component.getComponentVersionFormat().getReleaseVersionFormat());
+            }
+            if (matchesMajorVersionFormat(component, version, strict)) {
+                return numericVersion.formatVersion(component.getComponentVersionFormat().getMajorVersionFormat());
+            }
+            if (matchesLineVersionFormat(component, version, strict)) {
+                return numericVersion.formatVersion(getLineVersionFormat(component));
+            }
+        }
+        return null;
+    }
+
 
 }

--- a/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
+++ b/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.releng;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.octopusden.octopus.releng.dto.ComponentInfo;
 import org.octopusden.octopus.releng.dto.JiraComponent;

--- a/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
+++ b/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
@@ -209,11 +209,10 @@ public class JiraComponentVersionFormatter {
                 StringUtils.isNotBlank(jiraComponent.getComponentInfo().getVersionPrefix());
     }
 
-    @JsonIgnore
     public String normalizeVersion(JiraComponent component, String version, VersionNames versionNames, boolean isHotfixEnabled,  boolean strict) {
 
         if (component != null ) {
-            IVersionInfo numericVersion = new NumericVersionFactory(versionNames).create(version);
+            IVersionInfo numericVersion = numericVersionFactory.create(version);
             if (isHotfixEnabled && matchesHotfixVersionFormat(component, version, strict)) {
                 return numericVersion.formatVersion(component.getComponentVersionFormat().getHotfixVersionFormat());
             }

--- a/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
+++ b/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionFormatter.java
@@ -208,7 +208,7 @@ public class JiraComponentVersionFormatter {
                 StringUtils.isNotBlank(jiraComponent.getComponentInfo().getVersionPrefix());
     }
 
-    public String normalizeVersion(JiraComponent component, String version, boolean isHotfixEnabled, boolean strict) {
+    public String normalizeVersion(JiraComponent component, String version, boolean strict, boolean isHotfixEnabled) {
 
         if (component != null ) {
             IVersionInfo numericVersion = numericVersionFactory.create(version);

--- a/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionSerializer.java
+++ b/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionSerializer.java
@@ -71,6 +71,7 @@ public class JiraComponentVersionSerializer {
         }
     }
 
+    // todo - is there any usage of this method?
     public List<JiraComponentVersion> deserializeList(String jiraComponentVersionList) throws IOException {
         Validate.notNull(jiraComponentVersionList);
         jiraComponentVersionList = jiraComponentVersionList.replace("\n", "").replace("\r", "");
@@ -128,7 +129,7 @@ public class JiraComponentVersionSerializer {
         return new JiraComponentVersion(
                 ComponentVersion.create(componentName, releaseVersion),
                 jiraComponent,
-                jiraComponentVersionFormatter
+                jiraComponentVersionFormatter, false
         );
     }
 

--- a/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionSerializer.java
+++ b/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionSerializer.java
@@ -71,7 +71,6 @@ public class JiraComponentVersionSerializer {
         }
     }
 
-    // todo - is there any usage of this method?
     public List<JiraComponentVersion> deserializeList(String jiraComponentVersionList) throws IOException {
         Validate.notNull(jiraComponentVersionList);
         jiraComponentVersionList = jiraComponentVersionList.replace("\n", "").replace("\r", "");

--- a/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionSerializer.java
+++ b/src/main/java/org/octopusden/octopus/releng/JiraComponentVersionSerializer.java
@@ -123,12 +123,12 @@ public class JiraComponentVersionSerializer {
             componentName = componentItems[0];
         }
 
-        JiraComponent jiraComponent = new JiraComponent(projectKey, "", versionFormat, null, false);
+        JiraComponent jiraComponent = new JiraComponent(projectKey, "", versionFormat, null, false, false);
         JiraComponentVersionFormatter jiraComponentVersionFormatter = new JiraComponentVersionFormatter(versionNames);
         return new JiraComponentVersion(
                 ComponentVersion.create(componentName, releaseVersion),
                 jiraComponent,
-                jiraComponentVersionFormatter, false
+                jiraComponentVersionFormatter
         );
     }
 

--- a/src/main/java/org/octopusden/octopus/releng/dto/JiraComponent.java
+++ b/src/main/java/org/octopusden/octopus/releng/dto/JiraComponent.java
@@ -1,7 +1,6 @@
 package org.octopusden.octopus.releng.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.octopusden.releng.versions.ComponentVersionFormat;

--- a/src/main/java/org/octopusden/octopus/releng/dto/JiraComponent.java
+++ b/src/main/java/org/octopusden/octopus/releng/dto/JiraComponent.java
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.releng.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.octopusden.releng.versions.ComponentVersionFormat;
@@ -13,15 +14,19 @@ public class JiraComponent {
     private final ComponentVersionFormat componentVersionFormat;
     private final ComponentInfo componentInfo;
     private final boolean technical;
+    private final boolean isHotfixEnabled;
+
 
     @JsonCreator
     public JiraComponent(@JsonProperty("projectKey") String projectKey, @JsonProperty("displayName") String displayName, @JsonProperty("componentVersionFormat") ComponentVersionFormat componentVersionFormat,
-                         @JsonProperty("componentInfo") ComponentInfo componentInfo, @JsonProperty("technical") boolean technical) {
+                         @JsonProperty("componentInfo") ComponentInfo componentInfo, @JsonProperty("technical") boolean technical,
+                         @JsonProperty("isHotfixEnabled") Boolean isHotfixEnabled) {
         this.projectKey = projectKey;
         this.displayName = displayName;
         this.componentVersionFormat = componentVersionFormat;
         this.componentInfo = componentInfo;
         this.technical = technical;
+        this.isHotfixEnabled = isHotfixEnabled != null ? isHotfixEnabled : false; // Default to false if not specified
     }
 
     public String getProjectKey() {
@@ -42,6 +47,10 @@ public class JiraComponent {
 
     public boolean isTechnical() {
         return technical;
+    }
+
+    public boolean isHotfixEnabled() {
+        return isHotfixEnabled;
     }
 
     @Override
@@ -79,6 +88,7 @@ public class JiraComponent {
                 ", componentVersionFormat=" + componentVersionFormat +
                 ", componentInfo=" + componentInfo +
                 ", technical=" + technical +
+                ", isHotfixEnabled=" + isHotfixEnabled +
                 '}';
     }
 }

--- a/src/main/java/org/octopusden/octopus/releng/dto/JiraComponent.java
+++ b/src/main/java/org/octopusden/octopus/releng/dto/JiraComponent.java
@@ -13,19 +13,19 @@ public class JiraComponent {
     private final ComponentVersionFormat componentVersionFormat;
     private final ComponentInfo componentInfo;
     private final boolean technical;
-    private final boolean isHotfixEnabled;
+    private final boolean hotfixEnabled;
 
 
     @JsonCreator
     public JiraComponent(@JsonProperty("projectKey") String projectKey, @JsonProperty("displayName") String displayName, @JsonProperty("componentVersionFormat") ComponentVersionFormat componentVersionFormat,
                          @JsonProperty("componentInfo") ComponentInfo componentInfo, @JsonProperty("technical") boolean technical,
-                         @JsonProperty("isHotfixEnabled") Boolean isHotfixEnabled) {
+                         @JsonProperty("hotfixEnabled") Boolean hotfixEnabled) {
         this.projectKey = projectKey;
         this.displayName = displayName;
         this.componentVersionFormat = componentVersionFormat;
         this.componentInfo = componentInfo;
         this.technical = technical;
-        this.isHotfixEnabled = isHotfixEnabled != null ? isHotfixEnabled : false; // Default to false if not specified
+        this.hotfixEnabled = hotfixEnabled != null ? hotfixEnabled : false; // Default to false if not specified
     }
 
     public String getProjectKey() {
@@ -49,7 +49,7 @@ public class JiraComponent {
     }
 
     public boolean isHotfixEnabled() {
-        return isHotfixEnabled;
+        return hotfixEnabled;
     }
 
     @Override
@@ -65,7 +65,7 @@ public class JiraComponent {
                 .append(componentVersionFormat, that.componentVersionFormat)
                 .append(componentInfo, that.componentInfo)
                 .append(technical, that.technical)
-                .append(isHotfixEnabled, that.isHotfixEnabled)
+                .append(hotfixEnabled, that.hotfixEnabled)
                 .isEquals();
     }
 
@@ -77,7 +77,7 @@ public class JiraComponent {
                 .append(componentVersionFormat)
                 .append(componentInfo)
                 .append(technical)
-                .append(isHotfixEnabled)
+                .append(hotfixEnabled)
                 .toHashCode();
     }
 
@@ -89,7 +89,7 @@ public class JiraComponent {
                 ", componentVersionFormat=" + componentVersionFormat +
                 ", componentInfo=" + componentInfo +
                 ", technical=" + technical +
-                ", isHotfixEnabled=" + isHotfixEnabled +
+                ", isHotfixEnabled=" + hotfixEnabled +
                 '}';
     }
 }

--- a/src/main/java/org/octopusden/octopus/releng/dto/JiraComponent.java
+++ b/src/main/java/org/octopusden/octopus/releng/dto/JiraComponent.java
@@ -66,6 +66,7 @@ public class JiraComponent {
                 .append(componentVersionFormat, that.componentVersionFormat)
                 .append(componentInfo, that.componentInfo)
                 .append(technical, that.technical)
+                .append(isHotfixEnabled, that.isHotfixEnabled)
                 .isEquals();
     }
 
@@ -77,6 +78,7 @@ public class JiraComponent {
                 .append(componentVersionFormat)
                 .append(componentInfo)
                 .append(technical)
+                .append(isHotfixEnabled)
                 .toHashCode();
     }
 

--- a/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
+++ b/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
@@ -24,9 +24,6 @@ public class JiraComponentVersion {
     @JsonIgnore
     private final JiraComponentVersionFormatter jiraComponentVersionFormatter;
 
-    @JsonProperty
-    private final boolean isHotfixEnabled;
-
     @JsonIgnore
     private String lineVersion = null;
 
@@ -45,13 +42,10 @@ public class JiraComponentVersion {
     @JsonCreator
     public JiraComponentVersion(@JsonProperty("componentVersion") ComponentVersion componentVersion,
                                 @JsonProperty("component") JiraComponent component,
-                                JiraComponentVersionFormatter jiraComponentVersionFormatter,
-                                @JsonProperty("isHotfixEnabled") Boolean isHotfixEnabled) {
+                                JiraComponentVersionFormatter jiraComponentVersionFormatter) {
         this.componentVersion = componentVersion;
         this.component = component;
         this.jiraComponentVersionFormatter = jiraComponentVersionFormatter;
-        this.isHotfixEnabled = isHotfixEnabled != null ? isHotfixEnabled : false; // Default to false if not specified
-
     }
 
 
@@ -144,7 +138,7 @@ public class JiraComponentVersion {
 
     @JsonIgnore
     public String getHotfixVersion() {
-        if (isHotfixEnabled && hotfixVersion == null) {
+        if (component.isHotfixEnabled() && hotfixVersion == null) {
             String hotfixVersionFormat = jiraComponentVersionFormatter.getHotfixVersionFormat(getComponent());
             if (hotfixVersionFormat != null) {
                 hotfixVersion = jiraComponentVersionFormatter.getHotfixVersion(getComponent(), getVersion());
@@ -156,11 +150,6 @@ public class JiraComponentVersion {
     @JsonIgnore
     public String getRCVersion() {
         return getReleaseVersion() + RC_SUFFIX;
-    }
-
-    @JsonIgnore
-    public boolean isHotfixEnabled() {
-        return isHotfixEnabled;
     }
 
     @Override
@@ -193,7 +182,6 @@ public class JiraComponentVersion {
                 ", releaseVersion='" + getReleaseVersion() + '\'' +
                 ", buildVersion='" + getBuildVersion() + '\'' +
                 ", hotfixVersion='" + getHotfixVersion() + '\'' +
-                ", isHotfixEnabled=" + isHotfixEnabled +
                 '}';
     }
 }

--- a/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
+++ b/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
@@ -8,9 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.octopusden.octopus.releng.JiraComponentVersionFormatter;
-import org.octopusden.releng.versions.IVersionInfo;
-import org.octopusden.releng.versions.NumericVersionFactory;
-import org.octopusden.releng.versions.VersionNames;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
+++ b/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
@@ -23,6 +23,7 @@ public class JiraComponentVersion {
 
     @JsonProperty
     private final JiraComponent component;
+
     @JsonIgnore
     private final JiraComponentVersionFormatter jiraComponentVersionFormatter;
 
@@ -158,6 +159,11 @@ public class JiraComponentVersion {
     @JsonIgnore
     public String getRCVersion() {
         return getReleaseVersion() + RC_SUFFIX;
+    }
+
+    @JsonIgnore
+    public boolean isHotfixEnabled() {
+        return isHotfixEnabled;
     }
 
     @Override

--- a/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
+++ b/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
@@ -23,6 +23,9 @@ public class JiraComponentVersion {
     @JsonIgnore
     private final JiraComponentVersionFormatter jiraComponentVersionFormatter;
 
+    @JsonProperty
+    private final boolean isHotfixEnabled;
+
     @JsonIgnore
     private String lineVersion = null;
 
@@ -41,10 +44,13 @@ public class JiraComponentVersion {
     @JsonCreator
     public JiraComponentVersion(@JsonProperty("componentVersion") ComponentVersion componentVersion,
                                 @JsonProperty("component") JiraComponent component,
-                                JiraComponentVersionFormatter jiraComponentVersionFormatter) {
+                                JiraComponentVersionFormatter jiraComponentVersionFormatter,
+                                @JsonProperty("component") Boolean isHotfixEnabled) {
         this.componentVersion = componentVersion;
         this.component = component;
         this.jiraComponentVersionFormatter = jiraComponentVersionFormatter;
+        this.isHotfixEnabled = isHotfixEnabled != null ? isHotfixEnabled : false; // Default to false if not specified
+
     }
 
 

--- a/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
+++ b/src/main/java/org/octopusden/octopus/releng/dto/JiraComponentVersion.java
@@ -145,59 +145,6 @@ public class JiraComponentVersion {
     }
 
     @JsonIgnore
-    public String normalizeVersion(String version, VersionNames versionNames, boolean strict) {
-
-        if (component != null ) {
-            IVersionInfo numericVersion = new NumericVersionFactory(versionNames).create(version);
-            if (isHotfixEnabled && jiraComponentVersionFormatter.matchesHotfixVersionFormat(component, version, strict)) {
-                return numericVersion.formatVersion(component.getComponentVersionFormat().getHotfixVersionFormat());
-            }
-            if (jiraComponentVersionFormatter.matchesBuildVersionFormat(component, version, strict)) {
-                return numericVersion.formatVersion(jiraComponentVersionFormatter.getBuildVersionFormat(component));
-            }
-            if (jiraComponentVersionFormatter.matchesRCVersionFormat(component, version, strict)) {
-                return numericVersion.formatVersion(component.getComponentVersionFormat().getReleaseVersionFormat());
-            }
-            if (jiraComponentVersionFormatter.matchesReleaseVersionFormat(component, version, strict)) {
-                return numericVersion.formatVersion(component.getComponentVersionFormat().getReleaseVersionFormat());
-            }
-            if (jiraComponentVersionFormatter.matchesMajorVersionFormat(component, version, strict)) {
-                return numericVersion.formatVersion(component.getComponentVersionFormat().getMajorVersionFormat());
-            }
-            if (jiraComponentVersionFormatter.matchesLineVersionFormat(component, version, strict)) {
-                return numericVersion.formatVersion(jiraComponentVersionFormatter.getLineVersionFormat(component));
-            }
-        }
-        return null;
-    }
-
-    @JsonIgnore
-    public String getReleaseOrHotfixVersion() {
-        final String version;
-        if (null == getHotfixVersion()) {
-            version = getReleaseVersion();
-        } else {
-            version = getHotfixVersion();
-        }
-        return version;
-    }
-
-    @JsonIgnore
-    public boolean isHotfix() {
-        return getHotfixVersion() != null;
-    }
-
-    @JsonIgnore
-    public String getReleaseVersionForHotfix() {
-        if (getHotfixVersion() != null) {
-            return getReleaseVersion();
-        } else {
-            throw new IllegalStateException("Hotfix version is not set for component: " + getComponent().getDisplayName());
-        }
-    }
-
-
-    @JsonIgnore
     public String getHotfixVersion() {
         if (isHotfixEnabled && hotfixVersion == null) {
             String hotfixVersionFormat = jiraComponentVersionFormatter.getHotfixVersionFormat(getComponent());

--- a/src/main/kotlin/org/octopusden/octopus/releng/JiraComponentVersionDeserializer.kt
+++ b/src/main/kotlin/org/octopusden/octopus/releng/JiraComponentVersionDeserializer.kt
@@ -25,8 +25,7 @@ class JiraComponentVersionDeserializer(
         val componentVersion = getComponentVersion(node)
         val jiraComponent = getJiraComponent(node)
         val jiraComponentVersionFormatter = JiraComponentVersionFormatter(versionNames)
-        val isHotFixEnabled = getIsHotFixEnabled(node)
-        return JiraComponentVersion(componentVersion, jiraComponent, jiraComponentVersionFormatter, isHotFixEnabled)
+        return JiraComponentVersion(componentVersion, jiraComponent, jiraComponentVersionFormatter)
     }
 
     private fun getIsHotFixEnabled(node: JsonNode): Boolean {
@@ -77,13 +76,15 @@ class JiraComponentVersionDeserializer(
         val componentVersionFormat = getComponentVersionFormat(node)
         val componentInfo = getComponentInfo(node)
         val technical = getBooleanNode(node, "technical")
+        val isHotFixEnabled = getIsHotFixEnabled(node)
 
         return JiraComponent(
             projectKeyNode.toString(),
             getDisplayName(node),
             componentVersionFormat,
             componentInfo,
-            technical
+            technical,
+            isHotFixEnabled
         )
 
     }

--- a/src/main/kotlin/org/octopusden/octopus/releng/JiraComponentVersionDeserializer.kt
+++ b/src/main/kotlin/org/octopusden/octopus/releng/JiraComponentVersionDeserializer.kt
@@ -142,7 +142,7 @@ class JiraComponentVersionDeserializer(
         private const val COMPONENT = "component"
         private const val COMPONENT_VERSION_FORMAT = "componentVersionFormat"
         private const val COMPONENT_VERSION = "componentVersion"
-        private const val HOT_FIX_ENABLED = "isHotFixEnabled"
+        private const val HOT_FIX_ENABLED = "hotfixEnabled"
         private const val CUSTOMER_INFO = "customerInfo"
         private const val DISPLAY_NAME = "displayName"
     }

--- a/src/main/kotlin/org/octopusden/octopus/releng/JiraComponentVersionDeserializer.kt
+++ b/src/main/kotlin/org/octopusden/octopus/releng/JiraComponentVersionDeserializer.kt
@@ -25,7 +25,16 @@ class JiraComponentVersionDeserializer(
         val componentVersion = getComponentVersion(node)
         val jiraComponent = getJiraComponent(node)
         val jiraComponentVersionFormatter = JiraComponentVersionFormatter(versionNames)
-        return JiraComponentVersion(componentVersion, jiraComponent, jiraComponentVersionFormatter)
+        val isHotFixEnabled = getIsHotFixEnabled(node)
+        return JiraComponentVersion(componentVersion, jiraComponent, jiraComponentVersionFormatter, isHotFixEnabled)
+    }
+
+    private fun getIsHotFixEnabled(node: JsonNode): Boolean {
+        return if (node.get(HOT_FIX_ENABLED) != null) {
+            node.get(HOT_FIX_ENABLED).booleanValue()
+        } else {
+            false
+        }
     }
 
     private fun getComponentVersion(node: JsonNode): ComponentVersion? {
@@ -132,6 +141,7 @@ class JiraComponentVersionDeserializer(
         private const val COMPONENT = "component"
         private const val COMPONENT_VERSION_FORMAT = "componentVersionFormat"
         private const val COMPONENT_VERSION = "componentVersion"
+        private const val HOT_FIX_ENABLED = "isHotFixEnabled"
         private const val CUSTOMER_INFO = "customerInfo"
         private const val DISPLAY_NAME = "displayName"
     }

--- a/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionFormatterTest.java
+++ b/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionFormatterTest.java
@@ -117,13 +117,12 @@ class JiraComponentVersionFormatterTest {
     private JiraComponentVersion getJiraComponentVersionWithNullBuildVersion() {
         ComponentVersionFormat componentVersionFormat = ComponentVersionFormat.create("$major.$minor", "$major.$minor.$service-$fix",
                 null, null, null);
-        JiraComponent jiraComponent = new JiraComponent("C1", "C1", componentVersionFormat, null, true);
+        JiraComponent jiraComponent = new JiraComponent("C1", "C1", componentVersionFormat, null, true, false);
         ComponentVersion componentVersion = ComponentVersion.create("c1", "version");
         return new JiraComponentVersion(
                 componentVersion,
                 jiraComponent,
-                jiraComponentVersionFormatter,
-                false
+                jiraComponentVersionFormatter
         );
     }
 }

--- a/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionFormatterTest.java
+++ b/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionFormatterTest.java
@@ -18,7 +18,7 @@ class JiraComponentVersionFormatterTest {
             "serviceBranch", "service", "minor"
     );
     private final JiraComponentVersionFormatter jiraComponentVersionFormatter = new JiraComponentVersionFormatter(VERSION_NAMES);
-    private final JiraComponentVersion jiraComponentVersion = getJiraComponentVersion(jiraComponentVersionFormatter);
+    private final JiraComponentVersion jiraComponentVersion = getJiraComponentVersion(jiraComponentVersionFormatter, false);
 
     @Test
     void testGetJiraComponentVersion() {
@@ -122,7 +122,8 @@ class JiraComponentVersionFormatterTest {
         return new JiraComponentVersion(
                 componentVersion,
                 jiraComponent,
-                jiraComponentVersionFormatter
+                jiraComponentVersionFormatter,
+                false
         );
     }
 }

--- a/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionProvider.java
+++ b/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionProvider.java
@@ -8,7 +8,7 @@ import org.octopusden.releng.versions.ComponentVersionFormat;
 
 public class JiraComponentVersionProvider {
 
-    public static JiraComponentVersion getJiraComponentVersion(JiraComponentVersionFormatter jiraComponentVersionFormatter) {
+    public static JiraComponentVersion getJiraComponentVersion(JiraComponentVersionFormatter jiraComponentVersionFormatter, Boolean isHotfixEnabled) {
         ComponentVersionFormat componentVersionFormat = ComponentVersionFormat.create(
                 "$major.$minor",
                 "$major.$minor.$service",
@@ -18,10 +18,10 @@ public class JiraComponentVersionProvider {
         ComponentInfo componentInfo = new ComponentInfo("testcomponent", "$versionPrefix-$baseVersionFormat");
         JiraComponent jiraComponent = new JiraComponent("APP", "TestComponent Application", componentVersionFormat, componentInfo, true);
         ComponentVersion componentVersion = ComponentVersion.create("app-testcomponent", "2.15.1505.147-1128");
-        return new JiraComponentVersion(componentVersion, jiraComponent, jiraComponentVersionFormatter);
+        return new JiraComponentVersion(componentVersion, jiraComponent, jiraComponentVersionFormatter, isHotfixEnabled);
     }
 
-    public static JiraComponentVersion getJiraComponentVersionWithoutLineVersionFormat(JiraComponentVersionFormatter jiraComponentVersionFormatter) {
+    public static JiraComponentVersion getJiraComponentVersionWithoutLineVersionFormat(JiraComponentVersionFormatter jiraComponentVersionFormatter, Boolean isHotfixEnabled) {
         ComponentVersionFormat componentVersionFormat = ComponentVersionFormat.create("$major.$minor", "$major.$minor.$service-$fix",
                 "$major.$minor.$service.$fix-$build", null, null);
         ComponentInfo componentInfo = new ComponentInfo("testcomponent", "$versionPrefix-$baseVersionFormat");
@@ -30,7 +30,8 @@ public class JiraComponentVersionProvider {
         return new JiraComponentVersion(
                 componentVersion,
                 jiraComponent,
-                jiraComponentVersionFormatter
+                jiraComponentVersionFormatter,
+                isHotfixEnabled
         );
     }
 }

--- a/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionProvider.java
+++ b/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionProvider.java
@@ -16,22 +16,21 @@ public class JiraComponentVersionProvider {
                 "Line.$major.$minor",
                 "$major.$minor.$service.$fix-$build");
         ComponentInfo componentInfo = new ComponentInfo("testcomponent", "$versionPrefix-$baseVersionFormat");
-        JiraComponent jiraComponent = new JiraComponent("APP", "TestComponent Application", componentVersionFormat, componentInfo, true);
+        JiraComponent jiraComponent = new JiraComponent("APP", "TestComponent Application", componentVersionFormat, componentInfo, true, isHotfixEnabled);
         ComponentVersion componentVersion = ComponentVersion.create("app-testcomponent", "2.15.1505.147-1128");
-        return new JiraComponentVersion(componentVersion, jiraComponent, jiraComponentVersionFormatter, isHotfixEnabled);
+        return new JiraComponentVersion(componentVersion, jiraComponent, jiraComponentVersionFormatter);
     }
 
     public static JiraComponentVersion getJiraComponentVersionWithoutLineVersionFormat(JiraComponentVersionFormatter jiraComponentVersionFormatter, Boolean isHotfixEnabled) {
         ComponentVersionFormat componentVersionFormat = ComponentVersionFormat.create("$major.$minor", "$major.$minor.$service-$fix",
                 "$major.$minor.$service.$fix-$build", null, null);
         ComponentInfo componentInfo = new ComponentInfo("testcomponent", "$versionPrefix-$baseVersionFormat");
-        JiraComponent jiraComponent = new JiraComponent("APP", "TestComponent Application", componentVersionFormat, componentInfo, true);
+        JiraComponent jiraComponent = new JiraComponent("APP", "TestComponent Application", componentVersionFormat, componentInfo, true, isHotfixEnabled);
         ComponentVersion componentVersion = ComponentVersion.create("app-testcomponent", "2.15.1505.147-1128");
         return new JiraComponentVersion(
                 componentVersion,
                 jiraComponent,
-                jiraComponentVersionFormatter,
-                isHotfixEnabled
+                jiraComponentVersionFormatter
         );
     }
 }

--- a/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionSerializerTest.java
+++ b/src/test/java/org/octopusden/octopus/releng/JiraComponentVersionSerializerTest.java
@@ -25,14 +25,14 @@ class JiraComponentVersionSerializerTest {
 
     @Test
     void testSerialize() throws Exception {
-        JiraComponentVersion jiraComponentVersion = getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER);
+        JiraComponentVersion jiraComponentVersion = getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER, false);
         String jiraComponentVersionJson = jiraComponentVersionSerializer.serialize(jiraComponentVersion, true);
         assertEquals(jiraComponentVersion, jiraComponentVersionSerializer.deserialize(jiraComponentVersionJson));
     }
 
     @Test
     void testSerializeList() throws IOException {
-        List<JiraComponentVersion> jiraComponentVersionList = Collections.singletonList(getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER));
+        List<JiraComponentVersion> jiraComponentVersionList = Collections.singletonList(getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER, false));
         String jiraComponentVersionJson = jiraComponentVersionSerializer.serializeList(jiraComponentVersionList);
         assertEquals(jiraComponentVersionList, jiraComponentVersionSerializer.deserializeList(jiraComponentVersionJson));
     }
@@ -41,7 +41,7 @@ class JiraComponentVersionSerializerTest {
     void testSerializeLegacyFormat() throws IOException {
         String legacyFormat = Utils.getJson(this.getClass().getResourceAsStream("/dependencies-legacy.json"));
         JiraComponentVersion jiraComponentVersion = jiraComponentVersionSerializer.deserialize(legacyFormat);
-        JiraComponentVersion expected = getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER);
+        JiraComponentVersion expected = getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER, false);
         assertEquals(expected, jiraComponentVersion);
     }
 
@@ -49,7 +49,7 @@ class JiraComponentVersionSerializerTest {
     void testSerializeNewFormat() throws IOException {
         String newFormat = Utils.getJson(this.getClass().getResourceAsStream("/dependencies-new.json"));
         JiraComponentVersion jiraComponentVersion = jiraComponentVersionSerializer.deserialize(newFormat);
-        JiraComponentVersion expected = getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER);
+        JiraComponentVersion expected = getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER, false);
         assertEquals(expected, jiraComponentVersion);
     }
 
@@ -57,7 +57,7 @@ class JiraComponentVersionSerializerTest {
     void testValidJson() throws JsonProcessingException {
         assertFalse(jiraComponentVersionSerializer.isValidJSON("asd:$major.$minor:$major.$minor.$service:2.0.1"));
         assertTrue(jiraComponentVersionSerializer.isValidJSON("{\"id\": \"295cd59f-4033-438c-9bf4-c571829f134e\"}"));
-        String jiraComponentVersionJson = jiraComponentVersionSerializer.serialize(getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER));
+        String jiraComponentVersionJson = jiraComponentVersionSerializer.serialize(getJiraComponentVersion(JIRA_COMPONENT_VERSION_FORMATTER, false));
         assertTrue(jiraComponentVersionSerializer.isValidJSON(jiraComponentVersionJson));
     }
 }

--- a/src/test/kotlin/org/octopusden/octopus/releng/JiraComponentVersionTest.kt
+++ b/src/test/kotlin/org/octopusden/octopus/releng/JiraComponentVersionTest.kt
@@ -16,13 +16,13 @@ class JiraComponentVersionTest {
 
     @Test
     fun testGetLineVersionWhenFormatIsNotSpecified() {
-        val jiraComponentVersion: JiraComponentVersion = getJiraComponentVersionWithoutLineVersionFormat(jiraComponentVersionFormatter)
+        val jiraComponentVersion: JiraComponentVersion = getJiraComponentVersionWithoutLineVersionFormat(jiraComponentVersionFormatter, false)
         assertEquals(jiraComponentVersion.majorVersion, jiraComponentVersion.lineVersion)
     }
 
     @Test
     fun testGetLineVersionWhenFormatIsSpecified() {
-        val jiraComponentVersion: JiraComponentVersion = getJiraComponentVersion(jiraComponentVersionFormatter)
+        val jiraComponentVersion: JiraComponentVersion = getJiraComponentVersion(jiraComponentVersionFormatter, false)
         assertEquals("testcomponent-Line.2.15", jiraComponentVersion.lineVersion)
     }
 }


### PR DESCRIPTION
Initial task - https://github.com/octopusden/octopus-components-registry-service/issues/87

Phase 1 - **octopus-releng-lib**  ( https://github.com/octopusden/octopus-releng-lib/pull/16 )

- JiraComponent accepts hotfixEnabled in the constructor
- only if isHotfixEnabled set hotfixVersion can not be null
- method normalizeVersion in JiraComponentVersionFormatter to match proper format   

Phase 2 - **octopus-components-registry-service** ( https://github.com/octopusden/octopus-components-registry-service/pull/101 )

- ComponentHotfixSupportResolver finds by vcsSettings/hotFixBranch if isHotfixEnabled
- EscrowConfigurationLoader normalizes version string in resolveComponentConfiguration
